### PR TITLE
Create deploy-gh-pages.yml

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,19 @@
+name: Build and Deploy
+on:
+    push:
+        branches:
+            - main
+permissions:
+    contents: write
+jobs:
+    build-and-deploy:
+        concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout 🛎️
+              uses: actions/checkout@v4
+
+            - name: Deploy 🚀
+              uses: JamesIves/github-pages-deploy-action@v4
+              with:
+                  folder: docs # The folder the action should deploy.


### PR DESCRIPTION
Deploys the docs/index.html via github-pages

This pull request adds a .github/workflows/deploy-gh-pages.yml file. This is a GitHub Actions file that is run on each push to the main branch. It uses a another GitHub Action created by JamesIves. On a push to the main branch, a gh-pages branch is created and committed to with the contents of the docs/ directory of the repo, which already contains index.html file as of now. This file is detected by GitHub-Pages and is deployed and hosted by GitHub. 

This allows the index.html file to be kept up-to-date with pushes to main and increases accessibility.

NOTE: It may be necessary to alter the repo settings to "point" the GitHub-Pages to the newly created gh-pages branch. This is found within the repo "Settings" towards the top right of the main page of the repo, "Pages" within the "Code and automation" heading, and setting "Source" to "Deploy from a branch", and "Branch" to "gh-pages". 